### PR TITLE
Fixed bug with 'Index' not being in the TOC.

### DIFF
--- a/template/tmpl/container.tmpl
+++ b/template/tmpl/container.tmpl
@@ -4,7 +4,7 @@
 ?>
 <?js if (doc.kind === 'mainpage' || (doc.kind === 'package')) { ?>
 	<?js if (i === 0){ ?>
-	<span class="page-title"><?js= title ?></span>
+	<h1 class="page-title"><?js= title ?></h1>
 	<?js } ?>
 	<?js= self.partial('mainpage.tmpl', doc) ?>
 


### PR DESCRIPTION
Not sure why the Readme (index) page doesn't get an H1 title, so I made it happen.